### PR TITLE
Automatic SimpleDB permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,13 @@ regarding future development.
 
 # Installation
 
-1. Set up AWS credentials, with a profile called "claudia".
+1. Set up AWS credentials, with a profile called "claudia". (You can use `aws-credentials.example`
+   as a template by copying it to `~/.aws/credentials` and filling in your accesss id and key.)
+   See [Claudia set-up instructions](https://claudiajs.com/tutorials/installing.html) regarding
+   what policies the user needs to have.
 
-2. Copy `challonge.json.example` to `challonge.json` and enter Challonge organization sub-domain and Challonge user API key.
+2. Copy `challonge.json.example` to `challonge.json` and enter Challonge organization sub-domain
+   and Challonge user API key.
 
 3. Create Slack app.
 

--- a/README.md
+++ b/README.md
@@ -26,17 +26,17 @@ regarding future development.
 
 3. Create Slack app.
 
-4. Follow [Claudia set-up instructions](https://claudiajs.com/tutorials/installing.html) and deploy to AWS:
+4. Set up and deploy bot the first time to AWS:
    ```
-   npx claudia create --region eu-west-1 --api-module index --configure-slack-slash-app --profile claudia
+   npm run setup
    ```
 
-5. Add read / write policy for SimpleDB for the AWS IAM role (probably "tournie-executor").
 
 # Re-deploy / update
 
+To update the bot:
 ```
-npx claudia update --cache-api-config --profile claudia
+npm run update
 ```
 
 

--- a/aws-credentials.example
+++ b/aws-credentials.example
@@ -1,0 +1,3 @@
+[claudia]
+aws_access_key_id = AWS-ACCESS-ID
+aws_secret_access_key = AWS-ACCESS-KEY

--- a/aws-region.js
+++ b/aws-region.js
@@ -1,0 +1,13 @@
+
+let region;
+try {
+    const { lambda } = require('./claudia');
+    region = lambda.region;
+} catch (e) {
+    if (e.code !== 'MODULE_NOT_FOUND') {
+        throw e;
+    }
+    region = 'eu-west-1';
+}
+
+module.exports = region;

--- a/index.js
+++ b/index.js
@@ -1,10 +1,9 @@
-const axios = require('axios');
 const botBuilder = require('claudia-bot-builder');
 const challongeServiceFactory = require('./src/challonge.service');
 const userRepositoryFactory = require('./src/user.repository');
 const botFactory = require('./src/bot');
 const challongeConfig = require('./challonge');
-const { lambda: { region } } = require('./claudia');
+const region = require('./aws-region');
 
 const challongeService = challongeServiceFactory(challongeConfig);
 const userRepository = userRepositoryFactory({ region });

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "description": "Tournie Challonge bot for Slack",
   "main": "index.js",
   "scripts": {
+    "setup": "claudia create --profile claudia --region eu-west-1 --configure-slack-slash-app --api-module index --policies policies --timeout 6 --allow-recursion",
+    "update": "claudia update --profile claudia --cache-api-config",
     "test": "jest"
   },
   "repository": {

--- a/policies/simpledb-policy.json
+++ b/policies/simpledb-policy.json
@@ -1,0 +1,15 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Action": "sdb:ListDomains",
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": "sdb:*",
+            "Effect": "Allow",
+            "Resource": "arn:aws:sdb:*:*:domain/*"
+        }
+    ]
+}


### PR DESCRIPTION
This adds automatic SimpleDB permissions set-up (part of #11).

Also, `npm run` scripts are added, to ease set-up and deploy.

**Bonus fix:** Do not try to require `claudia.json` before it exists. During initial deploy, Claudia tries to invoke `index.js` as a smoke test.