### PR TITLE
Add message actions for help, login, tournaments commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 * Listing open tournaments for configured Challonge organization.
 * Connecting Slack user with Challonge member by "logging in". Suggestions from
   previous tournaments by configured Challonge organization.
+* Sign up for open tournaments.
 * Listing next matches for user, for tournaments s/he is part of.
 
 See the [Primer wiki page](/sebgrohn/tournie/wiki/Primer-on-Tournie-Challonge-bot)

--- a/src/bot.js
+++ b/src/bot.js
@@ -2,7 +2,6 @@ const R = require('ramda');
 const SlackTemplate = require('claudia-bot-builder').slackTemplate;
 const { formatTimestamp, formatDescription, formatGameName, formatMatch } = require('./formatting');
 
-const slashCommand = '/challonge';
 const supportedCommands = [
     ['[tournaments]', 'list open tournaments'],
     ['whoami', 'show who you are on Challonge'],
@@ -132,10 +131,11 @@ function botFactory(challongeService, userRepository) {
                 .get();
     }
 
-    function showUsage(message) {
+    function showUsage({ originalRequest }) {
+        const { command } = originalRequest;
         const supportedCommandsString = R.pipe(
-            R.map(([c, d]) => `• \`${slashCommand} ${c}\` to ${d}`),
-            R.join('\n')
+            R.map(([c, d]) => `• \`${command} ${c}\` to ${d}`),
+            R.join('\n'),
         )(supportedCommands);
 
         return new SlackTemplate()
@@ -145,8 +145,9 @@ function botFactory(challongeService, userRepository) {
             .get();
     }
 
-    function handleUnknown(message) {
-        return `:trophy: This is not how you win a game... Try \`${slashCommand} help\`.`;
+    function handleUnknown({ originalRequest }) {
+        const { command } = originalRequest;
+        return `:trophy: This is not how you win a game... Try \`${command} help\`.`;
     }
 
     function handleError(_, { response, message }) {

--- a/src/challonge.service.js
+++ b/src/challonge.service.js
@@ -105,6 +105,16 @@ function challongeServiceFactory({ organization, apiKey }) {
         )(tournamentsDetails);
     }
 
+    async function addTournamentParticipant(tournamentId, memberUsername, participantName = undefined) {
+        const { data } = await challongeApi.post(`tournaments/${tournamentId}/participants.json`, {
+            participant: {
+                challonge_username: memberUsername,
+                name: participantName,
+            },
+        });
+        return data.participant;
+    }
+
     return {
         fetchAllTournaments,
         fetchOpenTournaments,
@@ -112,6 +122,7 @@ function challongeServiceFactory({ organization, apiKey }) {
         fetchTournamentParticipants,
         fetchMembers,
         fetchOpenMatchesForMember,
+        addTournamentParticipant,
     };
 }
 

--- a/src/formatting.js
+++ b/src/formatting.js
@@ -17,6 +17,8 @@ function formatGameName(gameName) {
     }
 }
 
+const formatUser = ({ challongeUsername, challongeEmailHash }) => `*${challongeUsername}* (${challongeEmailHash ? 'verified' : 'unverified'})`;
+
 const formatMatch = (match, currentUserEmailHash) =>
     `${formatParticipant(match.player1, currentUserEmailHash)} vs ${formatParticipant(match.player2, currentUserEmailHash)}`;
 
@@ -30,6 +32,7 @@ module.exports = {
     formatTimestamp,
     formatDescription,
     formatGameName,
+    formatUser,
     formatMatch,
     formatParticipant,
 };

--- a/src/user.repository.js
+++ b/src/user.repository.js
@@ -28,17 +28,20 @@ function userRepositoryFactory({ region }) {
     }
 
     async function addUser(slackUserId, challongeUsername, challongeEmailHash = undefined) {
+        const user = { slackUserId, challongeUsername, challongeEmailHash };
         const attributes = R.pipe(
             R.toPairs,
             R.map(([Name, Value]) => ({ Name, Value })),
             R.filter(({ Value }) => Value),
-        )({ slackUserId, challongeUsername, challongeEmailHash });
+        )(user);
 
         await simpleDb.putAttributes({
             DomainName: userDomain,
             ItemName: slackUserId,
             Attributes: attributes,
         }).promise();
+
+        return user;
     }
 
     const deleteUser = slackUserId =>


### PR DESCRIPTION
Resolves #7.
Good start on #12.

I'm not totally happy with the relation between commands and their message action callback. Suggestions are welcome!

- [x] Update README.md with new feature: sign-up.
- [x] Merge npm-commands branch before this one.