### PR TITLE
Fix broken wiki link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 * Sign up for open tournaments.
 * Listing next matches for user, for tournaments s/he is part of.
 
-See the [Primer wiki page](/sebgrohn/tournie/wiki/Primer-on-Tournie-Challonge-bot)
+See the [Primer wiki page](https://github.com/sebgrohn/tournie/wiki/Primer-on-Tournie-Challonge-bot)
 regarding future development.
 
 


### PR DESCRIPTION
You can't relatively link to a wiki page in GitHub; use full URL instead. I really like this absolute URL but I guess it's fine for now. Maybe the wiki will die later on...

This was done incorrectly in #22.