### PR TITLE
Use commands connect / disconnect for logging in / out

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -6,11 +6,13 @@ function botFactory(handlers) {
     const commandHandlers = {
         tournaments: handlers.listOpenTournaments,
         whoami: handlers.showCurrentUser,
-        login: handlers.logInUser,
-        logout: handlers.logOutUser,
+        connect: handlers.logInUser,
+        disconnect: handlers.logOutUser,
+        login: handlers.logInUser, // alias for easy discovery
+        logout: handlers.logOutUser, // alias for easy discovery
         next: handlers.listNextMatches,
         help: handlers.showUsage,
-        usage: handlers.showUsage,
+        usage: handlers.showUsage, // alias for easy discovery
     };
 
     const callbackHandlers = {

--- a/src/handlers.js
+++ b/src/handlers.js
@@ -5,10 +5,10 @@ const SlackTemplate = require('claudia-bot-builder').slackTemplate;
 const supportedCommands = [
     ['[tournaments]', 'list open tournaments'],
     ['whoami', 'show who you are on Challonge'],
-    ['login [<challonge_username>]', 'connect your Slack and Challonge accounts'],
-    ['logout', 'disconnect your Slack and Challonge accounts'],
+    ['connect [<challonge_username>]', 'connect your Slack and Challonge accounts'],
+    ['disconnect', 'disconnect your Slack and Challonge accounts'],
     ['next', 'list open matches in tournaments you are part of'],
-    ['help|usage', 'show this information'],
+    ['help', 'show this information'],
 ];
 
 const unknownUserResponse = new SlackTemplate('I don\'t know who you are. :crying_cat_face:')


### PR DESCRIPTION
Follow [Slack's style guide for slash commands](https://api.slack.com/tutorials/slash-commands-style-guide). This PR takes care of the easy things such as naming of commands. Did I miss anything obvious?

Resolves #16.