### PR TITLE
Cleanup

### DIFF
--- a/src/BaseError.js
+++ b/src/BaseError.js
@@ -1,0 +1,15 @@
+
+class BaseError extends Error {
+    constructor(message) {
+        // Calling parent constructor of base Error class.
+        super(message);
+
+        // Saving class name in the property of our custom error as a shortcut.
+        this.name = this.constructor.name;
+
+        // Capturing stack trace, excluding constructor call from it.
+        Error.captureStackTrace(this, this.constructor);
+    }
+}
+
+module.exports = BaseError;

--- a/src/challonge.service.js
+++ b/src/challonge.service.js
@@ -47,8 +47,7 @@ const fetchMembers = ({ api, organization }) => async function () {
     const tournamentsDetails = await Promise.all(tournamentsDetailsPromises);
 
     return R.pipe(
-        R.map(({ participants }) => participants),
-        R.unnest,
+        R.chain(({ participants }) => participants),
         R.uniqBy(({ email_hash }) => email_hash),
         R.project(['username', 'email_hash', 'challonge_email_address_verified']),
     )(tournamentsDetails);
@@ -66,14 +65,12 @@ const fetchOpenMatchesForMember = ({ api, organization }) => async function (mem
     const tournamentsById = R.indexBy(t => t.id)(tournaments);
 
     const participantsById = R.pipe(
-        R.map(({ participants }) => participants),
-        R.unnest,
+        R.chain(({ participants }) => participants),
         R.indexBy(p => p.id),
     )(tournamentsDetails);
 
     return R.pipe(
-        R.map(({ matches }) => matches),
-        R.unnest,
+        R.chain(({ matches }) => matches),
         R.filter(({ state }) => ['pending', 'open'].includes(state)),
         R.map(m => ({
             ...m,

--- a/src/challonge.service.js
+++ b/src/challonge.service.js
@@ -18,7 +18,7 @@ const fetchOpenTournaments = ({ api, organization }) => async function () {
     });
     return R.pipe(
         R.map(({ tournament }) => tournament),
-        R.filter(t => ['pending', 'underway'].includes(t.state)),
+        R.filter(({ state }) => ['pending', 'underway'].includes(state)),
     )(data);
 };
 
@@ -36,26 +36,22 @@ const fetchTournament = ({ api }) => async function (tournamentId) {
     })(tournament);
 };
 
-const fetchTournamentParticipants = ({ api }) => async function (tournamentId) {
-    const { data } = await api.get(`tournaments/${tournamentId}/participants.json`);
-    return R.map(({ participant }) => participant)(data);
-};
-
 const fetchMembers = ({ api, organization }) => async function () {
     const tournaments = await fetchAllTournaments({ api, organization })();
 
-    const participantsPromises = R.pipe(
+    const tournamentsDetailsPromises = R.pipe(
         R.take(5),
         R.map(({ id }) => id),
-        R.map(fetchTournamentParticipants({ api })),
+        R.map(fetchTournament({ api })),
     )(tournaments);
-    const participants = await Promise.all(participantsPromises);
+    const tournamentsDetails = await Promise.all(tournamentsDetailsPromises);
 
     return R.pipe(
+        R.map(({ participants }) => participants),
         R.unnest,
         R.uniqBy(({ email_hash }) => email_hash),
         R.project(['username', 'email_hash', 'challonge_email_address_verified']),
-    )(participants);
+    )(tournamentsDetails);
 };
 
 const fetchOpenMatchesForMember = ({ api, organization }) => async function (memberEmailHash) {
@@ -78,7 +74,7 @@ const fetchOpenMatchesForMember = ({ api, organization }) => async function (mem
     return R.pipe(
         R.map(({ matches }) => matches),
         R.unnest,
-        R.filter(m => ['pending', 'open'].includes(m.state)),
+        R.filter(({ state }) => ['pending', 'open'].includes(state)),
         R.map(m => ({
             ...m,
             tournament: tournamentsById[m.tournament_id],
@@ -105,7 +101,6 @@ const challongeService = {
     fetchAllTournaments,
     fetchOpenTournaments,
     fetchTournament,
-    fetchTournamentParticipants,
     fetchMembers,
     fetchOpenMatchesForMember,
     addTournamentParticipant,

--- a/src/handlers.errors.js
+++ b/src/handlers.errors.js
@@ -1,0 +1,11 @@
+const BaseError = require('./BaseError');
+
+class InvalidCallbackActionError extends BaseError {
+    constructor({ callbackId }) {
+        super(`Invalid action value(s) for callback: ${callbackId}`);
+    }
+}
+
+module.exports = {
+    InvalidCallbackActionError,
+};

--- a/src/handlers.js
+++ b/src/handlers.js
@@ -17,183 +17,191 @@ const unknownUserResponse = new SlackTemplate('I don\'t know who you are. :cryin
     .replaceOriginal(false)
     .get();
 
-const handlers = {
-    listOpenTournaments: ({ challongeService, userRepository }) => async function ({ sender }) {
-        const userPromise = userRepository.getUser(sender);
-        const openTournamentsPromise = challongeService.fetchOpenTournaments();
-        const [user, openTournaments] = [await userPromise, await openTournamentsPromise];
+const listOpenTournaments = ({ challongeService, userRepository }) => async function ({ sender }) {
+    const userPromise = userRepository.getUser(sender);
+    const openTournamentsPromise = challongeService.fetchOpenTournaments();
+    const [user, openTournaments] = [await userPromise, await openTournamentsPromise];
 
-        return openTournaments.length === 0
-            ? 'There are no open tournaments. Is it time to start one? :thinking_face:'
-            : R.reduce(
-                (response, t) => {
-                    response
-                        .addAttachment('tournament')
-                        .addTitle(t.name, t.full_challonge_url)
-                        .addColor('#252830')
-                        .addField('Tournament', `${formatGameName(t.game_name)} – ${t.tournament_type}`, true)
-                        .addField('# Players', `${t.participants_count} / ${t.signup_cap}`, true);
+    return openTournaments.length === 0
+        ? 'There are no open tournaments. Is it time to start one? :thinking_face:'
+        : R.reduce(
+            (response, t) => {
+                response
+                    .addAttachment('tournament')
+                    .addTitle(t.name, t.full_challonge_url)
+                    .addColor('#252830')
+                    .addField('Tournament', `${formatGameName(t.game_name)} – ${t.tournament_type}`, true)
+                    .addField('# Players', `${t.participants_count} / ${t.signup_cap}`, true);
 
-                    if (t.description) {
-                        response.addText(formatDescription(t.description));
-                    }
+                if (t.description) {
+                    response.addText(formatDescription(t.description));
+                }
 
-                    if (t.started_at) {
-                        response.addField('Started', formatTimestamp(t.started_at), true);
+                if (t.started_at) {
+                    response.addField('Started', formatTimestamp(t.started_at), true);
+                } else {
+                    response.addField('Created', formatTimestamp(t.created_at), true);
+                    if (user) {
+                        response.addAction('Sign Up', 'sign_up', t.id);
                     } else {
-                        response.addField('Created', formatTimestamp(t.created_at), true);
-                        if (user) {
-                            response.addAction('Sign Up', 'sign_up', t.id);
-                        } else {
-                            response.addLinkButton('Sign Up', t.sign_up_url);
-                        }
+                        response.addLinkButton('Sign Up', t.sign_up_url);
                     }
+                }
 
-                    return response.addField('State', `${t.state} (${t.progress_meter}%)`, true);
-                },
-                new SlackTemplate('*:trophy: Open tournaments: :trophy:*'),
-            )(openTournaments)
-                .get();
-    },
-
-    signUpUserCallback: ({ challongeService, userRepository }) => async function ({ sender, originalRequest }) {
-        const user = await userRepository.getUser(sender);
-        if (!user) {
-            return unknownUserResponse;
-        }
-
-        const tournamentId = parseCallbackValue('sign_up', originalRequest);
-        if (!tournamentId) {
-            throw new InvalidCallbackActionError(originalRequest);
-        }
-
-        const tournamentPromise = challongeService.fetchTournament(tournamentId);
-        const addParticipantPromise = challongeService.addTournamentParticipant(tournamentId, user.challongeUsername);
-        const [tournament] = [await tournamentPromise, await addParticipantPromise];
-        return new SlackTemplate(`Awesome! You are now signed up for tournament *${tournament.name}.* :tada:`)
-            .replaceOriginal(false)
+                return response.addField('State', `${t.state} (${t.progress_meter}%)`, true);
+            },
+            new SlackTemplate('*:trophy: Open tournaments: :trophy:*'),
+        )(openTournaments)
             .get();
-    },
+};
 
-    showCurrentUser: ({ userRepository }) => async function ({ sender }) {
-        const user = await userRepository.getUser(sender);
-        if (!user) {
-            return unknownUserResponse;
-        }
-        return `You are known as ${formatUser(user)}. :ok_hand:`;
-    },
+const signUpUserCallback = ({ challongeService, userRepository }) => async function ({ sender, originalRequest }) {
+    const user = await userRepository.getUser(sender);
+    if (!user) {
+        return unknownUserResponse;
+    }
 
-    logInUser: ({ challongeService, userRepository }) => async function ({ text, sender }) {
-        let user = await userRepository.getUser(sender);
-        if (user) {
-            return `You are already logged in as ${formatUser(user)}. :angry:`;
+    const tournamentId = parseCallbackValue('sign_up', originalRequest);
+    if (!tournamentId) {
+        throw new InvalidCallbackActionError(originalRequest);
+    }
+
+    const tournamentPromise = challongeService.fetchTournament(tournamentId);
+    const addParticipantPromise = challongeService.addTournamentParticipant(tournamentId, user.challongeUsername);
+    const [tournament] = [await tournamentPromise, await addParticipantPromise];
+    return new SlackTemplate(`Awesome! You are now signed up for tournament *${tournament.name}.* :tada:`)
+        .replaceOriginal(false)
+        .get();
+};
+
+const showCurrentUser = ({ userRepository }) => async function ({ sender }) {
+    const user = await userRepository.getUser(sender);
+    if (!user) {
+        return unknownUserResponse;
+    }
+    return `You are known as ${formatUser(user)}. :ok_hand:`;
+};
+
+const logInUser = ({ challongeService, userRepository }) => async function ({ text, sender }) {
+    let user = await userRepository.getUser(sender);
+    if (user) {
+        return `You are already logged in as ${formatUser(user)}. :angry:`;
+    }
+
+    const challongeMembers = await challongeService.fetchMembers();
+    
+    const challongeUsername = text.split(/\s+/)[1];
+    if (challongeUsername) {
+        const { email_hash: challongeEmailHash } = R.find(m => m.username === challongeUsername)(challongeMembers) || {};
+
+        user = await userRepository.addUser(sender, challongeUsername, challongeEmailHash);
+        return `Congrats! You are now known as ${formatUser(user)}. :tada:`;
+    }
+
+    const response = new SlackTemplate()
+        .addAttachment('login')
+        .addText('Who are you? :simple_smile:')
+        .addColor('#252830');
+    response.getLatestAttachment().actions = [
+        {
+            type: 'select',
+            text: 'Select...',
+            name: 'username',
+            options: R.map(({ username }) => ({
+                text: username,
+                value: username,
+            }))(challongeMembers),
+        },
+    ];
+    return response.get();
+};
+
+const logInUserCallback = ({ challongeService, userRepository }) => async function ({ sender, originalRequest }) {
+    let user = await userRepository.getUser(sender);
+    if (!user) {
+        const challongeUsername = parseCallbackValue('username', originalRequest);
+        if (!challongeUsername) {
+            throw new InvalidCallbackActionError(originalRequest);
         }
 
         const challongeMembers = await challongeService.fetchMembers();
-        
-        const challongeUsername = text.split(/\s+/)[1];
-        if (challongeUsername) {
-            const { email_hash: challongeEmailHash } = R.find(m => m.username === challongeUsername)(challongeMembers) || {};
+        const { email_hash: challongeEmailHash } = R.find(m => m.username === challongeUsername)(challongeMembers) || {};
 
-            user = await userRepository.addUser(sender, challongeUsername, challongeEmailHash);
-            return `Congrats! You are now known as ${formatUser(user)}. :tada:`;
-        }
+        user = await userRepository.addUser(sender, challongeUsername, challongeEmailHash);
+    }
 
-        const response = new SlackTemplate()
-            .addAttachment('login')
-            .addText('Who are you? :simple_smile:')
-            .addColor('#252830');
-        response.getLatestAttachment().actions = [
-            {
-                type: 'select',
-                text: 'Select...',
-                name: 'username',
-                options: R.map(({ username }) => ({
-                    text: username,
-                    value: username,
-                }))(challongeMembers),
-            },
-        ];
-        return response.get();
-    },
-
-    logInUserCallback: ({ challongeService, userRepository }) => async function ({ sender, originalRequest }) {
-        let user = await userRepository.getUser(sender);
-        if (!user) {
-            const challongeUsername = parseCallbackValue('username', originalRequest);
-            if (!challongeUsername) {
-                throw new InvalidCallbackActionError(originalRequest);
-            }
-
-            const challongeMembers = await challongeService.fetchMembers();
-            const { email_hash: challongeEmailHash } = R.find(m => m.username === challongeUsername)(challongeMembers) || {};
-
-            user = await userRepository.addUser(sender, challongeUsername, challongeEmailHash);
-        }
-
-        return new SlackTemplate()
-            .addAttachment('login_verified')
-            .addText(`Who are you? :simple_smile:\n\nCongrats! You are now known as ${formatUser(user)}. :tada:`)
-            .addColor('#252830')
-            .get();
-    },
-
-    logOutUser: ({ userRepository }) => async function ({ sender }) {
-        const user = await userRepository.getUser(sender);
-        if (!user) {
-            return unknownUserResponse;
-        }
-        await userRepository.deleteUser(sender);
-        return 'Okay, you are now forgotten. I hope to see you later! :wave:';
-    },
-
-    listNextMatches: ({ challongeService, userRepository }) => async function ({ sender }) {
-        const user = await userRepository.getUser(sender);
-        if (!user) {
-            return unknownUserResponse;
-        }
-
-        const openMatches = await challongeService.fetchOpenMatchesForMember(user.challongeEmailHash);
-
-        // TODO get users corresponding to opponents to show matching Slack nicks
-
-        return openMatches.length === 0
-            ? 'You have no matches to play. :sweat_smile:'
-            : R.reduce(
-                (response, m) => response
-                    .addAttachment('match')
-                    .addTitle(m.tournament.name, m.tournament.full_challonge_url)
-                    .addText(formatMatch(m, user.challongeEmailHash))
-                    .addColor('#252830')
-                    .addField('Tournament', `${formatGameName(m.tournament.game_name)} – ${m.tournament.tournament_type} (${m.tournament.progress_meter}%)`, true)
-                    .addField('Match opened', m.started_at ? formatTimestamp(m.started_at) : 'Pending opponent', true),
-                new SlackTemplate('*:trophy: Your open matches: :trophy:*'),
-            )(openMatches)
-                .get();
-    },
-
-    showUsage: () => function ({ originalRequest }) {
-        const { command } = originalRequest;
-        const supportedCommandsString = R.pipe(
-            R.map(([c, d]) => `• \`${command} ${c}\` to ${d}`),
-            R.join('\n'),
-        )(supportedCommands);
-
-        return new SlackTemplate()
-            .addAttachment('usage')
-            .addText(`Supported commands:\n${supportedCommandsString}`)
-            .addColor('#252830')
-            .addAction('Close', 'close', 'close')
-            .get();
-    },
-
-    closeUsageCallback: () => function ({ originalRequest }) {
-        const shouldClose = !!parseCallbackValue('close', originalRequest);
-        if (!shouldClose) {
-            throw new InvalidCallbackActionError(originalRequest);
-        }
-        return { delete_original: true }; // NOTE SlackTemplate doesn't support this flag
-    },
+    return new SlackTemplate()
+        .addAttachment('login_verified')
+        .addText(`Who are you? :simple_smile:\n\nCongrats! You are now known as ${formatUser(user)}. :tada:`)
+        .addColor('#252830')
+        .get();
 };
 
-module.exports = handlers;
+const logOutUser = ({ userRepository }) => async function ({ sender }) {
+    const user = await userRepository.getUser(sender);
+    if (!user) {
+        return unknownUserResponse;
+    }
+    await userRepository.deleteUser(sender);
+    return 'Okay, you are now forgotten. I hope to see you later! :wave:';
+};
+
+const listNextMatches = ({ challongeService, userRepository }) => async function ({ sender }) {
+    const user = await userRepository.getUser(sender);
+    if (!user) {
+        return unknownUserResponse;
+    }
+
+    const openMatches = await challongeService.fetchOpenMatchesForMember(user.challongeEmailHash);
+
+    // TODO get users corresponding to opponents to show matching Slack nicks
+
+    return openMatches.length === 0
+        ? 'You have no matches to play. :sweat_smile:'
+        : R.reduce(
+            (response, m) => response
+                .addAttachment('match')
+                .addTitle(m.tournament.name, m.tournament.full_challonge_url)
+                .addText(formatMatch(m, user.challongeEmailHash))
+                .addColor('#252830')
+                .addField('Tournament', `${formatGameName(m.tournament.game_name)} – ${m.tournament.tournament_type} (${m.tournament.progress_meter}%)`, true)
+                .addField('Match opened', m.started_at ? formatTimestamp(m.started_at) : 'Pending opponent', true),
+            new SlackTemplate('*:trophy: Your open matches: :trophy:*'),
+        )(openMatches)
+            .get();
+};
+
+const showUsage = () => function ({ originalRequest }) {
+    const { command } = originalRequest;
+    const supportedCommandsString = R.pipe(
+        R.map(([c, d]) => `• \`${command} ${c}\` to ${d}`),
+        R.join('\n'),
+    )(supportedCommands);
+
+    return new SlackTemplate()
+        .addAttachment('usage')
+        .addText(`Supported commands:\n${supportedCommandsString}`)
+        .addColor('#252830')
+        .addAction('Close', 'close', 'close')
+        .get();
+};
+
+const closeUsageCallback = () => function ({ originalRequest }) {
+    const shouldClose = !!parseCallbackValue('close', originalRequest);
+    if (!shouldClose) {
+        throw new InvalidCallbackActionError(originalRequest);
+    }
+    return { delete_original: true }; // NOTE SlackTemplate doesn't support this flag
+};
+
+module.exports = {
+    listOpenTournaments,
+    signUpUserCallback,
+    showCurrentUser,
+    logInUser,
+    logInUserCallback,
+    logOutUser,
+    listNextMatches,
+    showUsage,
+    closeUsageCallback,
+};

--- a/src/handlers.js
+++ b/src/handlers.js
@@ -29,10 +29,13 @@ const handlers = {
                     response
                         .addAttachment('tournament')
                         .addTitle(t.name, t.full_challonge_url)
-                        .addText(formatDescription(t.description))
                         .addColor('#252830')
                         .addField('Tournament', `${formatGameName(t.game_name)} – ${t.tournament_type}`, true)
                         .addField('# Players', `${t.participants_count} / ${t.signup_cap}`, true);
+
+                    if (t.description) {
+                        response.addText(formatDescription(t.description));
+                    }
 
                     if (t.started_at) {
                         response.addField('Started', formatTimestamp(t.started_at), true);

--- a/src/handlers.utils.js
+++ b/src/handlers.utils.js
@@ -3,10 +3,9 @@ const R = require('ramda');
 const parseCallbackValue = (actionName, { actions }) =>
     R.pipe(
         R.filter(({ name }) => name === actionName),
-        R.map(({ selected_options, value }) => selected_options
+        R.chain(({ selected_options, value }) => selected_options
             ? selected_options
             : [{ value }]),
-        R.unnest,
         R.map(({ value }) => value),
         R.head,
     )(actions) || {};

--- a/src/handlers.utils.js
+++ b/src/handlers.utils.js
@@ -1,0 +1,16 @@
+const R = require('ramda');
+
+const parseCallbackValue = (actionName, { actions }) =>
+    R.pipe(
+        R.filter(({ name }) => name === actionName),
+        R.map(({ selected_options, value }) => selected_options
+            ? selected_options
+            : [{ value }]),
+        R.unnest,
+        R.map(({ value }) => value),
+        R.head,
+    )(actions) || {};
+
+module.exports = {
+    parseCallbackValue,
+};

--- a/src/user.repository.js
+++ b/src/user.repository.js
@@ -2,50 +2,53 @@ const R = require('ramda');
 
 const userDomain = 'tournie-users';
 
-const userRepository = {
-    initialize: db => () =>
-        // NOTE createDomain does nothing when the domain already exists
-        db.createDomain({ DomainName: userDomain }).promise(),
+const initialize = db => () =>
+    // NOTE createDomain does nothing when the domain already exists
+    db.createDomain({ DomainName: userDomain }).promise();
 
-    getUser: db => async function(slackUserId) {
-        const { Attributes } = await db.getAttributes({
-            DomainName: userDomain,
-            ItemName: slackUserId,
-            AttributeNames: ['slackUserId', 'challongeUsername', 'challongeEmailHash'],
-        }).promise();
+const getUser = db => async function(slackUserId) {
+    const { Attributes } = await db.getAttributes({
+        DomainName: userDomain,
+        ItemName: slackUserId,
+        AttributeNames: ['slackUserId', 'challongeUsername', 'challongeEmailHash'],
+    }).promise();
 
-        if (!Attributes) {
-            return undefined;
-        }
+    if (!Attributes) {
+        return undefined;
+    }
 
-        return R.pipe(
-            R.map(({ Name, Value }) => [Name, Value]),
-            R.fromPairs,
-        )(Attributes);
-    },
-
-    addUser: db => async function(slackUserId, challongeUsername, challongeEmailHash = undefined) {
-        const user = { slackUserId, challongeUsername, challongeEmailHash };
-        const attributes = R.pipe(
-            R.toPairs,
-            R.map(([Name, Value]) => ({ Name, Value })),
-            R.filter(({ Value }) => Value),
-        )(user);
-
-        await db.putAttributes({
-            DomainName: userDomain,
-            ItemName: slackUserId,
-            Attributes: attributes,
-        }).promise();
-
-        return user;
-    },
-
-    deleteUser: db => slackUserId =>
-        db.deleteAttributes({
-            DomainName: userDomain,
-            ItemName: slackUserId,
-        }).promise(),
+    return R.pipe(
+        R.map(({ Name, Value }) => [Name, Value]),
+        R.fromPairs,
+    )(Attributes);
 };
 
-module.exports = userRepository;
+const addUser = db => async function(slackUserId, challongeUsername, challongeEmailHash = undefined) {
+    const user = { slackUserId, challongeUsername, challongeEmailHash };
+    const attributes = R.pipe(
+        R.toPairs,
+        R.map(([Name, Value]) => ({ Name, Value })),
+        R.filter(({ Value }) => Value),
+    )(user);
+
+    await db.putAttributes({
+        DomainName: userDomain,
+        ItemName: slackUserId,
+        Attributes: attributes,
+    }).promise();
+
+    return user;
+};
+
+const deleteUser = db => slackUserId =>
+    db.deleteAttributes({
+        DomainName: userDomain,
+        ItemName: slackUserId,
+    }).promise();
+
+module.exports = {
+    initialize,
+    getUser,
+    addUser,
+    deleteUser,
+};


### PR DESCRIPTION
Mixed bag:

* Fix, do not try to show empty tournament description.
* Replace `R.map` + `R.unnest` -> `R.chain`. Resolves #36.
* Refactor Challonge service to remove redundant method `fetchTournamentParticipants` (and improve tests.
* Create utility function for parsing callback action values + use specific error type for such validation errors.
* Declare handlers  and user repository methods top-level in their respective modules. *Tip:* ignore white-space changes in diff.