### PR TITLE
Add sign-up command

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 * Listing open tournaments for configured Challonge organization.
 * Connecting Slack user with Challonge member by "logging in". Suggestions from
   previous tournaments by configured Challonge organization.
-* Sign up for open tournaments.
+* Signing up for open tournaments.
 * Listing next matches for user, for tournaments s/he is part of.
 
 See the [Primer wiki page](https://github.com/sebgrohn/tournie/wiki/Primer-on-Tournie-Challonge-bot)

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const botFactory = require('./src/bot');
 const { apiKey, organization } = require('./challonge');
 const region = require('./aws-region');
 const challongeServiceFactory = R.applySpec(require('./src/challonge.service'));
-const handlersFactory =  R.applySpec(require('./src/handlers'));
+const handlersFactory = R.applySpec(require('./src/handlers'));
 const userRepositoryFactory = R.applySpec(require('./src/user.repository'));
 
 const api = axios.create({
@@ -18,7 +18,7 @@ const api = axios.create({
 });
 const simpleDb = new SimpleDB({ region });
 
-const challongeService =  challongeServiceFactory({ api, organization });
+const challongeService = challongeServiceFactory({ api, organization });
 const userRepository = userRepositoryFactory(simpleDb);
 const handlers = handlersFactory({ challongeService, userRepository });
 const bot = botFactory(handlers);

--- a/src/bot.js
+++ b/src/bot.js
@@ -12,14 +12,16 @@ function botFactory(handlers) {
         disconnect: handlers.logOutUser,
         login: handlers.logInUser, // alias for easy discovery
         logout: handlers.logOutUser, // alias for easy discovery
+        signup: handlers.signUpUser,
         next: handlers.listNextMatches,
         help: handlers.showUsage,
         usage: handlers.showUsage, // alias for easy discovery
     };
 
     const callbackHandlers = {
-        tournament: handlers.signUpUserCallback,
+        tournament: handlers.signUpUserFromListCallback,
         login: handlers.logInUserCallback,
+        signup: handlers.signUpUserCallback,
         usage: handlers.closeUsageCallback,
     };
 

--- a/src/challonge.service.js
+++ b/src/challonge.service.js
@@ -49,7 +49,7 @@ const fetchMembers = ({ api, organization }) => async function () {
     )(tournamentsDetails);
 };
 
-const fetchOpenTournamentsForMember = ({ api, organization }) => async function (memberEmailHash, { signedUp = undefined, includeUnderway = true } = {}) {
+const fetchOpenTournamentsForMember = ({ api, organization }) => async function (memberEmailHash, { signedUpFilter = undefined, includeUnderway = true } = {}) {
     const tournaments = await fetchOpenTournaments({ api, organization })(includeUnderway);
 
     const tournamentsDetailsPromises = R.pipe(
@@ -58,18 +58,12 @@ const fetchOpenTournamentsForMember = ({ api, organization }) => async function 
     )(tournaments);
     const tournamentsDetails = await Promise.all(tournamentsDetailsPromises);
 
-    const filterFunc = R.cond([
-        [R.equals(true), () => R.equals(true)],
-        [R.equals(false), () => R.equals(false)],
-        [R.T, () => R.T],
-    ])(signedUp);
-
     return R.pipe(
         R.map(t => ({
             ...t,
             is_signed_up: R.any(({ email_hash }) => email_hash === memberEmailHash)(t.participants),
         })),
-        R.filter(({ is_signed_up }) => filterFunc(is_signed_up)),
+        R.filter(({ is_signed_up }) => R.isNil(signedUpFilter) || is_signed_up === signedUpFilter),
     )(tournamentsDetails);
 };
 

--- a/src/challonge.service.js
+++ b/src/challonge.service.js
@@ -4,22 +4,15 @@ const fetchAllTournaments = ({ api, organization }) => async function () {
     const { data } = await api.get('tournaments.json', {
         params: {
             subdomain: organization,
+            // state: '...', // one of 'all', 'pending', 'in_progress', 'ended'
         },
     });
     return R.map(({ tournament }) => tournament)(data);
 };
 
 const fetchOpenTournaments = ({ api, organization }) => async function () {
-    const { data } = await api.get('tournaments.json', {
-        params: {
-            subdomain: organization,
-            // state: '...', // one of 'all', 'pending', 'in_progress', 'ended'
-        },
-    });
-    return R.pipe(
-        R.map(({ tournament }) => tournament),
-        R.filter(({ state }) => ['pending', 'underway'].includes(state)),
-    )(data);
+    const tournaments = await fetchAllTournaments({ api, organization })();
+    return R.filter(({ state }) => ['pending', 'underway'].includes(state))(tournaments);
 };
 
 const fetchTournament = ({ api }) => async function (tournamentId) {

--- a/src/challonge.service.test.js
+++ b/src/challonge.service.test.js
@@ -165,7 +165,7 @@ test('fetchOpenTournamentsForMember signed up', async () => {
     const spyFunc = jest.fn();
     const api = mockApi(spyFunc);
     const tournaments = await challongeService
-        .fetchOpenTournamentsForMember({ api, organization })(memberEmailHash, { signedUp: true });
+        .fetchOpenTournamentsForMember({ api, organization })(memberEmailHash, { signedUpFilter: true });
 
     expect(spyFunc.mock.calls).toHaveLength(4);
     expect(spyFunc.mock.calls[0])
@@ -208,7 +208,7 @@ test('fetchOpenTournamentsForMember NOT signed up', async () => {
     const spyFunc = jest.fn();
     const api = mockApi(spyFunc);
     const tournaments = await challongeService
-        .fetchOpenTournamentsForMember({ api, organization })(memberEmailHash, { signedUp: false });
+        .fetchOpenTournamentsForMember({ api, organization })(memberEmailHash, { signedUpFilter: false });
 
     expect(spyFunc.mock.calls).toHaveLength(4);
     expect(spyFunc.mock.calls[0])

--- a/src/challonge.service.test.js
+++ b/src/challonge.service.test.js
@@ -29,6 +29,24 @@ const t2 = {
     ],
     matches: [],
 };
+const t3 = {
+    id: 't3',
+    state: 'pending',
+    participants: [
+        { participant: p1 },
+        { participant: p2 },
+    ],
+    matches: [],
+};
+const t4 = {
+    id: 't4',
+    state: 'pending',
+    participants: [
+        { participant: p1 },
+        { participant: p3 },
+    ],
+    matches: [],
+};
 
 const mockApi = spyFunc => ({
     get: async (route, query) => {
@@ -39,6 +57,8 @@ const mockApi = spyFunc => ({
                     data: [
                         { tournament: t1 },
                         { tournament: t2 },
+                        { tournament: t3 },
+                        { tournament: t4 },
                     ],
                 };
             case 'tournaments/t1.json':
@@ -48,6 +68,14 @@ const mockApi = spyFunc => ({
             case 'tournaments/t2.json':
                 return {
                     data: { tournament: t2 },
+                };
+            case 'tournaments/t3.json':
+                return {
+                    data: { tournament: t3 },
+                };
+            case 'tournaments/t4.json':
+                return {
+                    data: { tournament: t4 },
                 };
             default:
                 return undefined;
@@ -71,7 +99,7 @@ test('fetchAllTournaments', async () => {
     expect(spyFunc.mock.calls).toHaveLength(1);
     expect(spyFunc.mock.calls[0])
         .toEqual(['tournaments.json', { params: { subdomain: 'company' } }]);
-    expect(tournaments).toEqual([t1, t2]);
+    expect(tournaments).toEqual([t1, t2, t3, t4]);
 });
 
 test('fetchOpenTournaments', async () => {
@@ -83,7 +111,7 @@ test('fetchOpenTournaments', async () => {
     expect(spyFunc.mock.calls).toHaveLength(1);
     expect(spyFunc.mock.calls[0])
         .toEqual(['tournaments.json', { params: { subdomain: 'company' } }]);
-    expect(tournaments).toEqual([t1]);
+    expect(tournaments).toEqual([t1, t3, t4]);
 });
 
 test('fetchTournament', async () => {
@@ -113,17 +141,95 @@ test('fetchMembers', async () => {
     const members = await challongeService
         .fetchMembers({ api, organization })();
 
-    expect(spyFunc.mock.calls).toHaveLength(3);
+    expect(spyFunc.mock.calls).toHaveLength(5);
     expect(spyFunc.mock.calls[0])
         .toEqual(['tournaments.json', { params: { subdomain: 'company' } }]);
     expect(spyFunc.mock.calls[1])
         .toEqual(['tournaments/t1.json', { params: { include_matches: 1, include_participants: 1 } }]);
     expect(spyFunc.mock.calls[2])
         .toEqual(['tournaments/t2.json', { params: { include_matches: 1, include_participants: 1 } }]);
+    expect(spyFunc.mock.calls[3])
+        .toEqual(['tournaments/t3.json', { params: { include_matches: 1, include_participants: 1 } }]);
+    expect(spyFunc.mock.calls[4])
+        .toEqual(['tournaments/t4.json', { params: { include_matches: 1, include_participants: 1 } }]);
     expect(members).toEqual([
         memberView(p1),
         memberView(p2),
         memberView(p3),
+    ]);
+});
+
+test('fetchOpenTournamentsForMember signed up', async () => {
+    const memberEmailHash = 'email_hash2';
+
+    const spyFunc = jest.fn();
+    const api = mockApi(spyFunc);
+    const tournaments = await challongeService
+        .fetchOpenTournamentsForMember({ api, organization })(memberEmailHash, { signedUp: true });
+
+    expect(spyFunc.mock.calls).toHaveLength(4);
+    expect(spyFunc.mock.calls[0])
+        .toEqual(['tournaments.json', { params: { subdomain: 'company' } }]);
+    expect(spyFunc.mock.calls[1])
+        .toEqual(['tournaments/t1.json', { params: { include_matches: 1, include_participants: 1 } }]);
+    expect(spyFunc.mock.calls[2])
+        .toEqual(['tournaments/t3.json', { params: { include_matches: 1, include_participants: 1 } }]);
+    expect(spyFunc.mock.calls[3])
+        .toEqual(['tournaments/t4.json', { params: { include_matches: 1, include_participants: 1 } }]);
+    expect(tournaments).toEqual([
+        {
+            id: 't1',
+            state: 'underway',
+            participants: [
+                { id: 'p1', username: 'username1', email_hash: 'email_hash1', challonge_email_address_verified: 'challonge_email_address_verified1' },
+                { id: 'p2', username: 'username2', email_hash: 'email_hash2', challonge_email_address_verified: 'challonge_email_address_verified2' },
+            ],
+            is_signed_up: true,
+            matches: [ 
+                { state: 'open', player1_id: 'p1', player2_id: 'p2' },
+            ],
+        },
+        {
+            id: 't3',
+            state: 'pending',
+            participants: [
+                { id: 'p1', username: 'username1', email_hash: 'email_hash1', challonge_email_address_verified: 'challonge_email_address_verified1' },
+                { id: 'p2', username: 'username2', email_hash: 'email_hash2', challonge_email_address_verified: 'challonge_email_address_verified2' },
+            ],
+            is_signed_up: true,
+            matches: [],
+        },
+    ]);
+});
+
+test('fetchOpenTournamentsForMember NOT signed up', async () => {
+    const memberEmailHash = 'email_hash2';
+
+    const spyFunc = jest.fn();
+    const api = mockApi(spyFunc);
+    const tournaments = await challongeService
+        .fetchOpenTournamentsForMember({ api, organization })(memberEmailHash, { signedUp: false });
+
+    expect(spyFunc.mock.calls).toHaveLength(4);
+    expect(spyFunc.mock.calls[0])
+        .toEqual(['tournaments.json', { params: { subdomain: 'company' } }]);
+    expect(spyFunc.mock.calls[1])
+        .toEqual(['tournaments/t1.json', { params: { include_matches: 1, include_participants: 1 } }]);
+    expect(spyFunc.mock.calls[2])
+        .toEqual(['tournaments/t3.json', { params: { include_matches: 1, include_participants: 1 } }]);
+    expect(spyFunc.mock.calls[3])
+        .toEqual(['tournaments/t4.json', { params: { include_matches: 1, include_participants: 1 } }]);
+    expect(tournaments).toEqual([
+        {
+            id: 't4',
+            state: 'pending',
+            participants: [
+                { id: 'p1', username: 'username1', email_hash: 'email_hash1', challonge_email_address_verified: 'challonge_email_address_verified1' },
+                { id: 'p3', username: 'username3', email_hash: 'email_hash3', challonge_email_address_verified: 'challonge_email_address_verified3' },
+            ],
+            is_signed_up: false,
+            matches: [],
+        },
     ]);
 });
 
@@ -134,11 +240,15 @@ test('fetchOpenMatchesForMember', async () => {
     const matches = await challongeService
         .fetchOpenMatchesForMember({ api, organization })(memberEmailHash);
 
-    expect(spyFunc.mock.calls).toHaveLength(2);
+    expect(spyFunc.mock.calls).toHaveLength(4);
     expect(spyFunc.mock.calls[0])
         .toEqual(['tournaments.json', { params: { subdomain: 'company' } }]);
     expect(spyFunc.mock.calls[1])
         .toEqual(['tournaments/t1.json', { params: { include_matches: 1, include_participants: 1 } }]);
+    expect(spyFunc.mock.calls[2])
+        .toEqual(['tournaments/t3.json', { params: { include_matches: 1, include_participants: 1 } }]);
+    expect(spyFunc.mock.calls[3])
+        .toEqual(['tournaments/t4.json', { params: { include_matches: 1, include_participants: 1 } }]);
     expect(matches).toEqual([
         {
             player1: {

--- a/src/formatting.js
+++ b/src/formatting.js
@@ -6,6 +6,8 @@ const formatTimestamp = isoTimestampString => isoTimestampString;
 const formatDescription = description =>
     slackify(description.replace(/<\s*br\s*\/?\s*>/, '\n'));
 
+const formatTournamentType = (gameName, tournamentType) => `${formatGameName(gameName)} – ${tournamentType}`;
+
 function formatGameName(gameName) {
     switch (gameName.toLowerCase()) {
         case 'table tennis':
@@ -35,6 +37,7 @@ const formatParticipant = (participant, currentUserEmailHash) => participant
 module.exports = {
     formatTimestamp,
     formatDescription,
+    formatTournamentType,
     formatGameName,
     formatNumPlayers,
     formatUser,

--- a/src/formatting.js
+++ b/src/formatting.js
@@ -17,6 +17,10 @@ function formatGameName(gameName) {
     }
 }
 
+const formatNumPlayers = (participantsCount, signupCap) => signupCap
+    ? `${participantsCount} / ${signupCap}`
+    : `${participantsCount}`;
+
 const formatUser = ({ challongeUsername, challongeEmailHash }) => `*${challongeUsername}* (${challongeEmailHash ? 'verified' : 'unverified'})`;
 
 const formatMatch = (match, currentUserEmailHash) =>
@@ -32,6 +36,7 @@ module.exports = {
     formatTimestamp,
     formatDescription,
     formatGameName,
+    formatNumPlayers,
     formatUser,
     formatMatch,
     formatParticipant,

--- a/src/handlers.js
+++ b/src/handlers.js
@@ -147,7 +147,7 @@ const logOutUser = chain(
 const signUpUser = chain(
     validateUser,
     ({ challongeService }) => async ({ user }) => {
-        const notSignedUpTournaments = await challongeService.fetchOpenTournamentsForMember(user.challongeEmailHash, { signedUp: false, includeUnderway: false });
+        const notSignedUpTournaments = await challongeService.fetchOpenTournamentsForMember(user.challongeEmailHash, { signedUpFilter: false, includeUnderway: false });
         return notSignedUpTournaments.length > 0
             ? Promise.resolve(notSignedUpTournaments)
             : Promise.reject(new HandlerError('There are currently no tournaments where you can sign up.'));

--- a/src/handlers.js
+++ b/src/handlers.js
@@ -2,7 +2,7 @@ const R = require('ramda');
 const SlackTemplate = require('claudia-bot-builder').slackTemplate;
 const HandlerError = require('./HandlerError');
 const { chain, concurrent, validateUser, tryGetUser, validateNoUser, validateCallbackValue } = require('./handlers.utils');
-const { formatTimestamp, formatDescription, formatGameName, formatNumPlayers, formatUser, formatMatch } = require('./formatting');
+const { formatTimestamp, formatDescription, formatTournamentType, formatGameName, formatNumPlayers, formatUser, formatMatch } = require('./formatting');
 
 const supportedCommands = [
     ['[tournaments]', 'list open tournaments'],
@@ -30,7 +30,7 @@ const listOpenTournaments = chain(
                     .addAttachment('tournament')
                     .addTitle(t.name, t.full_challonge_url)
                     .addColor('#252830')
-                    .addField('Tournament', `${formatGameName(t.game_name)} – ${t.tournament_type}`, true)
+                    .addField('Tournament', formatTournamentType(t.game_name, t.tournament_type), true)
                     .addField('# Players', formatNumPlayers(t.participants_count, t.signup_cap), true);
 
                 if (t.description) {

--- a/src/handlers.js
+++ b/src/handlers.js
@@ -2,7 +2,7 @@ const R = require('ramda');
 const SlackTemplate = require('claudia-bot-builder').slackTemplate;
 const HandlerError = require('./HandlerError');
 const { chain, concurrent, validateUser, tryGetUser, validateNoUser, validateCallbackValue } = require('./handlers.utils');
-const { formatTimestamp, formatDescription, formatGameName, formatUser, formatMatch } = require('./formatting');
+const { formatTimestamp, formatDescription, formatGameName, formatNumPlayers, formatUser, formatMatch } = require('./formatting');
 
 const supportedCommands = [
     ['[tournaments]', 'list open tournaments'],
@@ -31,7 +31,7 @@ const listOpenTournaments = chain(
                     .addTitle(t.name, t.full_challonge_url)
                     .addColor('#252830')
                     .addField('Tournament', `${formatGameName(t.game_name)} – ${t.tournament_type}`, true)
-                    .addField('# Players', `${t.participants_count} / ${t.signup_cap}`, true);
+                    .addField('# Players', formatNumPlayers(t.participants_count, t.signup_cap), true);
 
                 if (t.description) {
                     response.addText(formatDescription(t.description));

--- a/src/handlers.test.js
+++ b/src/handlers.test.js
@@ -2,8 +2,9 @@ const handlers = require('./handlers');
 
 test('listOpenTournaments', async () => {
     const challongeService = {
-        fetchOpenTournaments: async () => [
+        fetchOpenTournamentsForMember: async () => [
             {
+                id: 't1',
                 name: 'a',
                 full_challonge_url: 'a_full_challonge_url',
                 description: 'a_description',
@@ -16,6 +17,7 @@ test('listOpenTournaments', async () => {
                 progress_meter: 'a_progress_meter',
             },
             {
+                id: 't2',
                 name: 'b',
                 full_challonge_url: 'b_full_challonge_url',
                 description: 'b_description',


### PR DESCRIPTION
Add `signup` command for signing up to open tournaments. Also improve the existing sign-up functionality of the `tournaments` command.

Resolves #12.